### PR TITLE
Stations ln

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  helper_method :current_user, :current_admin?
+
   def require_admin
     render file: "/public/404" unless current_admin?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+
+  def current_user
+  @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  def current_admin?
+    current_user && current_user.admin?
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,19 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.find_by(username: params[:username])
+    if user && user.authenticate(params[:password])
+      session[:user_id] = user.id
+      redirect_to user_path(user)
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    session.destroy
+    redirect_to root_path
+  end
+end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -29,8 +29,10 @@ class StationsController < ApplicationController
 
   def update
     if @station.update(station_params)
+      flash[:notice] = "Station updated"
       redirect_to station_path(@station)
     else
+      flash[:notice] = "Station not updated. Try again."
       render :edit
     end
   end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -1,7 +1,50 @@
 class StationsController < ApplicationController
+  before_action :find_station, only: [:edit, :show, :update, :destroy]
 
   def index
     @stations = Station.all
   end
-  
+
+  def new
+    @station = Station.new
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def create
+    @station = Station.new(station_params)
+    if @station.save
+      redirect_to station_path(@station)
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @station.update(station_params)
+      redirect_to station_path(@station)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @station.destroy
+    redirect_to stations_path
+  end
+
+  private
+
+    def station_params
+      params.require(:station).permit(:name, :dock_count, :city, :installation_date)
+    end
+
+    def find_station
+      @station = Station.find(params[:id])
+    end
+
 end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -1,5 +1,6 @@
 class StationsController < ApplicationController
   before_action :find_station, only: [:edit, :show, :update, :destroy]
+  before_action :require_admin, only: [:edit, :update, :destroy, :new]
 
   def index
     @stations = Station.all

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -1,0 +1,7 @@
+class StationsController < ApplicationController
+
+  def index
+    @stations = Station.all
+  end
+  
+end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -19,8 +19,10 @@ class StationsController < ApplicationController
   def create
     @station = Station.new(station_params)
     if @station.save
+      flash[:notice] = "Station created"
       redirect_to station_path(@station)
     else
+      flash[:notice] = "Station not created. Try again."
       render :new
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,40 @@
+class UsersController < ApplicationController
+
+  def new
+    @user = User.new
+  end
+
+  def show
+    @user = current_user
+  end
+
+  def edit
+    @user = current_user
+  end
+
+  def create
+    user = User.new(user_params)
+    if user.save
+      session[:user_id] = user.id
+      redirect_to user_path(user)
+    else
+      render :new
+    end
+  end
+
+  def update
+    user = current_user
+    user.update(user_params)
+    if user.save
+      redirect_to user_path(user)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:username, :password)
+    end
+end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,0 +1,3 @@
+class Station < ApplicationRecord
+  validates_presence_of :name, :dock_count, :city, :installation_date
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  has_secure_password
+  validates_presence_of :name, :password
+  validates_uniqueness_of :name
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
-  validates_presence_of :name, :password
-  validates_uniqueness_of :name
+  validates_presence_of :name, :password, :email
+  validates_uniqueness_of :name, :email
 
   enum role: ["default", "admin"]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@ class User < ApplicationRecord
   has_secure_password
   validates_presence_of :name, :password
   validates_uniqueness_of :name
+
+  enum role: ["default", "admin"]
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
   </head>
 
   <body>
+    <% if flash[:notice] %>
+      <div class="notice"><%= flash[:notice] %></div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/stations/_form.html.erb
+++ b/app/views/stations/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for @station do |f| %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :dock_count %>
+  <%= f.number_field :dock_count %>
+
+  <%= f.label :city %>
+  <%= f.text_field :city %>
+
+  <%= f.label :installation_date %>
+  <%= f.date_field :installation_date %>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/stations/edit.html.erb
+++ b/app/views/stations/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form" %>

--- a/app/views/stations/index.html.erb
+++ b/app/views/stations/index.html.erb
@@ -3,4 +3,6 @@
   Dock Count: <%= station.dock_count %>
   City: <%= station.city %>
   Installation Date: <%= station.installation_date %>
+  <%= link_to "Edit", edit_station_path(station) if current_admin? %>
+  <%= link_to "Delete", station_path(station), method: "delete" if current_admin? %>
 <% end %>

--- a/app/views/stations/index.html.erb
+++ b/app/views/stations/index.html.erb
@@ -1,0 +1,6 @@
+<% @stations.each do |station| %>
+  Name: <%= station.name %>
+  Dock Count: <%= station.dock_count %>
+  City: <%= station.city %>
+  Installation Date: <%= station.installation_date %>
+<% end %>

--- a/app/views/stations/index.html.erb
+++ b/app/views/stations/index.html.erb
@@ -1,3 +1,4 @@
+<%= link_to "Create New Station", new_station_path if current_admin? %>
 <% @stations.each do |station| %>
   Name: <%= station.name %>
   Dock Count: <%= station.dock_count %>

--- a/app/views/stations/new.html.erb
+++ b/app/views/stations/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form" %>

--- a/app/views/stations/show.html.erb
+++ b/app/views/stations/show.html.erb
@@ -1,0 +1,6 @@
+Name: <%= @station.name %>
+Dock Count: <%= @station.dock_count %>
+City: <%= @station.city %>
+Installation Date: <%= @station.installation_date %>
+<%= link_to "Edit", edit_station_path(@station) if current_admin? %>
+<%= link_to "Delete", station_path(@station), method: "delete" if current_admin? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resources :stations
+
 end

--- a/db/migrate/20180217194039_create_stations.rb
+++ b/db/migrate/20180217194039_create_stations.rb
@@ -1,0 +1,12 @@
+class CreateStations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :stations do |t|
+      t.text :name
+      t.integer :dock_count
+      t.text :city
+      t.datetime :installation_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180217194039_create_stations.rb
+++ b/db/migrate/20180217194039_create_stations.rb
@@ -5,8 +5,6 @@ class CreateStations < ActiveRecord::Migration[5.1]
       t.integer :dock_count
       t.text :city
       t.datetime :installation_date
-
-      t.timestamps
     end
   end
 end

--- a/db/migrate/20180217220153_create_users.rb
+++ b/db/migrate/20180217220153_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180217220153_create_users.rb
+++ b/db/migrate/20180217220153_create_users.rb
@@ -3,6 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
     create_table :users do |t|
       t.string :name
       t.string :password_digest
+      t.integer :role, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20180217220153_create_users.rb
+++ b/db/migrate/20180217220153_create_users.rb
@@ -3,6 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
     create_table :users do |t|
       t.string :name
       t.string :password_digest
+      t.string :email
       t.integer :role, default: 0
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180217194039) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "stations", force: :cascade do |t|
+    t.text "name"
+    t.integer "dock_count"
+    t.text "city"
+    t.datetime "installation_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20180217220153) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "password_digest"
+    t.string "email"
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180217194039) do
+ActiveRecord::Schema.define(version: 20180217220153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,11 @@ ActiveRecord::Schema.define(version: 20180217194039) do
     t.integer "dock_count"
     t.text "city"
     t.datetime "installation_date"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20180217220153) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "password_digest"
+    t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,7 +4,7 @@
 
 # Benefits (why)
 
-# Possbile Drawbacks (optional)
+# Possible Drawbacks (optional)
 
 # Checklist:
 

--- a/spec/factories/stations.rb
+++ b/spec/factories/stations.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :station do
+    name "MyText"
+    dock_count 1
+    city "MyText"
+    installation_date "2018-02-17 12:40:39"
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    name "MyText"
+    password_digest "MyText"
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,12 @@
 FactoryBot.define do
   factory :user do
-    name "MyText"
-    password_digest "MyText"
+    name "User"
+    password "User"
+  end
+
+  factory :admin, class: User do
+    name "Admin"
+    password "Admin"
+    role 1
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,11 +2,13 @@ FactoryBot.define do
   factory :user do
     name "User"
     password "User"
+    email "UserEmail"
   end
 
   factory :admin, class: User do
     name "Admin"
     password "Admin"
+    email "AdminEmail"
     role 1
   end
 end

--- a/spec/features/stations/admin_can_create_a_new_station_spec.rb
+++ b/spec/features/stations/admin_can_create_a_new_station_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "As an Admin" do
+  before :each do
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+  describe "when I visit stations/new" do
+    it "I can create a new station" do
+      visit new_station_path
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[city]", with: "Um, Bay area?"
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Create Station"
+
+      expect(current_path).to eq("/stations/1")
+      expect(page).to have_content("Name: Opakawagalaga")
+    end
+
+    it "I can see a flash message for success" do
+      visit new_station_path
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[city]", with: "Um, Bay area?"
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Create Station"
+
+      expect(page).to have_content("Station created")
+    end
+
+    it "I can see a flash message for errors" do
+      visit new_station_path
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Create Station"
+
+      expect(page).to have_content("Station not created. Try again.")
+    end
+  end
+end

--- a/spec/features/stations/admin_can_edit_an_existing_station_spec.rb
+++ b/spec/features/stations/admin_can_edit_an_existing_station_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "As an Admin" do
+  before :each do
+    @admin = create(:admin)
+    @station = create(:station)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+  describe "when I visit stations/:id/edit" do
+    it "I can update a specific station" do
+      visit edit_station_path(@station)
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[city]", with: "Um, Bay area?"
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Update Station"
+
+      expect(page).to have_content("Name: Opakawagalaga")
+    end
+
+    it "I can see a flash message for a success" do
+      visit edit_station_path(@station)
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[city]", with: "Um, Bay area?"
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Update Station"
+
+      expect(page).to have_content("Station updated")
+    end
+
+    it "I can see a flash message for an error" do
+      visit edit_station_path(@station)
+
+      fill_in "station[name]", with: "Opakawagalaga"
+      fill_in "station[dock_count]", with: "1"
+      fill_in "station[city]", with: ""
+      fill_in "station[installation_date]", with: Time.now
+      click_on "Update Station"
+
+      expect(page).to have_content("Station not updated. Try again.")
+    end
+  end
+end

--- a/spec/features/stations/admin_can_see_all_the_stations_spec.rb
+++ b/spec/features/stations/admin_can_see_all_the_stations_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "As an Admin" do
+  before :each do
+    @admin = create(:admin)
+    @station = create(:station)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+  describe "when I visit the stations index page" do
+    it "I can see everything a visitor can see" do
+      visit stations_path
+
+      expect(page).to have_content("Name: #{@station.name}")
+      expect(page).to have_content("Dock Count: #{@station.dock_count}")
+      expect(page).to have_content("City: #{@station.city}")
+      expect(page).to have_content("Installation Date: #{@station.installation_date}")
+    end
+
+    it "I can also see a delete button" do
+      visit stations_path
+
+      expect(page).to have_content("Delete")
+    end
+
+    it "I can also see an edit button" do
+      visit stations_path
+
+      expect(page).to have_content("Edit")
+    end
+  end
+end

--- a/spec/features/stations/visitor_can_see_all_stations_spec.rb
+++ b/spec/features/stations/visitor_can_see_all_stations_spec.rb
@@ -28,5 +28,11 @@ describe "As a Visitor" do
 
       expect(page).to have_content("Installation Date: #{@station.installation_date}")
     end
+
+    it "I can't see admin buttons" do
+      visit stations_path
+
+      expect(page).to_not have_content("Edit")
+    end
   end
 end

--- a/spec/features/stations/visitor_cannot_edit_or_create_a_station_spec.rb
+++ b/spec/features/stations/visitor_cannot_edit_or_create_a_station_spec.rb
@@ -11,4 +11,12 @@ describe "As a visitor" do
       expect(page).to have_content("The page you were looking for doesn't exist")
     end
   end
+
+  describe "when I try to visit stations/new" do
+    it "I am redirected to a 404 page" do
+      visit new_station_path
+
+      expect(page).to have_content("The page you were looking for doesn't exist")
+    end
+  end
 end

--- a/spec/features/stations/visitor_cannot_edit_or_delete_a_station_spec.rb
+++ b/spec/features/stations/visitor_cannot_edit_or_delete_a_station_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe "As a visitor" do
+  before :each do
+    @station = create(:station)
+  end
+  describe "when I try to visit stations/:id/edit" do
+    it "I am redirected to a 404 page" do
+      visit edit_station_path(@station)
+
+      expect(page).to have_content("The page you were looking for doesn't exist")
+    end
+  end
+end

--- a/spec/features/visitor_can_see_all_stations_spec.rb
+++ b/spec/features/visitor_can_see_all_stations_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe "As a Visitor" do
+  before :each do
+    @station = create(:station)
+  end
+  describe "When I visit the stations index" do
+    it "I see all stations names" do
+      visit stations_path
+
+      expect(page).to have_content(@station.name)
+    end
+
+    it "I see all stations names" do
+      visit stations_path
+
+      expect(page).to have_content(@station.dock_count)
+    end
+
+    it "I see all stations names" do
+      visit stations_path
+
+      expect(page).to have_content(@station.city)
+    end
+
+    it "I see all stations names" do
+      visit stations_path
+
+      expect(page).to have_content(@station.installation_date)
+    end
+  end
+end

--- a/spec/features/visitor_can_see_all_stations_spec.rb
+++ b/spec/features/visitor_can_see_all_stations_spec.rb
@@ -5,28 +5,28 @@ describe "As a Visitor" do
     @station = create(:station)
   end
   describe "When I visit the stations index" do
-    it "I see all stations names" do
+    it "I see all station's names" do
       visit stations_path
 
-      expect(page).to have_content(@station.name)
+      expect(page).to have_content("Name: #{@station.name}")
     end
 
-    it "I see all stations names" do
+    it "I see all station's dock counts" do
       visit stations_path
 
-      expect(page).to have_content(@station.dock_count)
+      expect(page).to have_content("Dock Count: #{@station.dock_count}")
     end
 
-    it "I see all stations names" do
+    it "I see all station's cities" do
       visit stations_path
 
-      expect(page).to have_content(@station.city)
+      expect(page).to have_content("City: #{@station.city}")
     end
 
-    it "I see all stations names" do
+    it "I see all station's installation date" do
       visit stations_path
 
-      expect(page).to have_content(@station.installation_date)
+      expect(page).to have_content("Installation Date: #{@station.installation_date}")
     end
   end
 end

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Station, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:dock_count) }
+  it { should validate_presence_of(:city) }
+  it { should validate_presence_of(:installation_date) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:password) }
+  it { should validate_presence_of(:email) }
   it { should validate_uniqueness_of(:name) }
+  it { should validate_uniqueness_of(:email) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:password) }
+  it { should validate_uniqueness_of(:name) }
+end


### PR DESCRIPTION
# Added Features:

* Visitor can see the stations index with all stations
* Only admin can create a new station
* Only admin can edit a station
* Build out show page for station
* Only admin can delete a station
* Fix minor typo in pull request template

# Benefits (why)

Admins have most of the CRUD functionality for stations. Visitors and users can see the stations, but they only have the R functionality.

# Possible Drawbacks (optional)

The authorization and authentication works, but I would like a second set of eyes on it to make sure I set it up correctly.

# Checklist:

Answer the following questions -
* Are all tests passing? Y
* Have you tested your new feature? Y
* Have you tested it on localhost? Y

# Additional Comments:

We should probably work on some styling. We should also set up seeds, I've done neither
