### PR TITLE
Trips crud

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format=documentation

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 gem 'friendly_id', '~> 5.1.0'
+gem 'kaminari'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,18 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -207,6 +219,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.0)
   friendly_id (~> 5.1.0)
   jbuilder (~> 2.5)
+  kaminari
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
@@ -222,4 +235,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,0 +1,6 @@
+class TripsController < ApplicationController
+
+  def index
+    @trips = Trip.all
+  end
+end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,11 +1,40 @@
 class TripsController < ApplicationController
   before_action :find_trip, only: [:show, :edit, :update, :destroy]
+  before_action :require_admin, only: [:edit, :update, :destroy, :new]
 
   def index
     @trips = Trip.order(:start_date).page params[:page]
   end
 
+  def new
+    @trip = Trip.new
+  end
+
+  def create
+    @trip = Trip.new(trip_params)
+    if @trip.save
+      flash[:notice] = "Trip created"
+      redirect_to trip_path(@trip)
+    else
+      flash[:notice] = "Trip not created. Try again."
+      render :new
+    end
+  end
+
   def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @trip.update(trip_params)
+      flash[:notice] = "Trip updated ;)"
+      redirect_to trip_path(@trip)
+    else
+      flash[:notice] = "Trip not updated. Try again."
+      render :edit
+    end
   end
 
   def destroy
@@ -18,5 +47,9 @@ class TripsController < ApplicationController
 
   def find_trip
     @trip = Trip.find(params[:id])
+  end
+
+  def trip_params
+    params.require(:trip).permit(:duration, :start_date, :start_station_id, :end_date, :end_station_id, :bike_id, :subscription_type, :zip_code)
   end
 end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,6 +1,16 @@
 class TripsController < ApplicationController
+  before_action :find_trip, only: [:show, :edit, :update, :destroy]
 
   def index
     @trips = Trip.order(:start_date).page params[:page]
+  end
+
+  def show
+  end
+
+  private
+
+  def find_trip
+    @trip = Trip.find(params[:id])
   end
 end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -8,6 +8,12 @@ class TripsController < ApplicationController
   def show
   end
 
+  def destroy
+    @trip.destroy
+    flash[:notice] = "Trip deleted =("
+    redirect_to trips_path
+  end
+
   private
 
   def find_trip

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,6 +1,6 @@
 class TripsController < ApplicationController
 
   def index
-    @trips = Trip.all
+    @trips = Trip.order(:start_date).page params[:page]
   end
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,6 +4,9 @@ class Station < ApplicationRecord
 
   validates_presence_of :name, :dock_count, :city, :installation_date
 
+  has_many :start_trips, class_name: "Trip", foreign_key: "start_station_id"
+  has_many :end_trips, class_name: "Trip", foreign_key: "end_station_id"
+
   def self.average_bike_count
     average(:dock_count)
   end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,0 +1,4 @@
+class Trip < ApplicationRecord
+  validates_presence_of :duration, :start_date, :start_station_id, :end_date, :end_station_id, :bike_id, :subscription_type, :zip_code
+
+end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,5 +1,5 @@
 class Trip < ApplicationRecord
-  validates_presence_of :duration, :start_date, :end_date, :bike_id, :subscription_type, :zip_code
+  validates_presence_of :duration, :start_date, :start_station_id, :end_date, :end_station_id, :bike_id, :subscription_type, :zip_code
 
   belongs_to :start_station, class_name: 'Station'
   belongs_to :end_station, class_name: 'Station'

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,3 +1,6 @@
 class Trip < ApplicationRecord
   validates_presence_of :duration, :start_date, :end_date, :bike_id, :subscription_type, :zip_code
+
+  belongs_to :start_station, class_name: 'Station'
+  belongs_to :end_station, class_name: 'Station'
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,4 +1,3 @@
 class Trip < ApplicationRecord
-  validates_presence_of :duration, :start_date, :start_station_id, :end_date, :end_station_id, :bike_id, :subscription_type, :zip_code
-
+  validates_presence_of :duration, :start_date, :end_date, :bike_id, :subscription_type, :zip_code
 end

--- a/app/views/trips/_form.html.erb
+++ b/app/views/trips/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for @trip do |f|  %>
+
+  <%= f.label :duration %>
+  <%= f.number_field :duration %>
+
+  <%= f.label :start_date %>
+  <%= f.date_field :start_date %>
+
+  <%= f.label :start_station_id %>
+  <%= f.number_field :start_station_id %>
+
+  <%= f.label :end_date %>
+  <%= f.date_field :end_date %>
+
+  <%= f.label :end_station_id %>
+  <%= f.number_field :end_station_id %>
+
+  <%= f.label :bike_id %>
+  <%= f.number_field :bike_id %>
+
+  <%= f.label :subscription_type %>
+  <%= f.text_field :subscription_type %>
+
+  <%= f.label :zip_code %>
+  <%= f.number_field :zip_code %>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/trips/edit.html.erb
+++ b/app/views/trips/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form" %>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -1,0 +1,11 @@
+<% @trips.each do |trip| %>
+  <%= trip.id %>  
+  <%= trip.duration %>
+  <%= trip.start_date %>
+  <%= trip.start_station.name %>
+  <%= trip.end_date %>
+  <%= trip.end_station.name %>
+  <%= trip.bike_id %>
+  <%= trip.subscription_type %>
+  <%= trip.zip_code %>
+<% end %>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -1,11 +1,12 @@
 <% @trips.each do |trip| %>
-  <%= trip.id %>  
-  <%= trip.duration %>
-  <%= trip.start_date %>
-  <%= trip.start_station.name %>
-  <%= trip.end_date %>
-  <%= trip.end_station.name %>
-  <%= trip.bike_id %>
-  <%= trip.subscription_type %>
-  <%= trip.zip_code %>
+  Trip ID: <%= trip.id %> <br>
+  <%= trip.duration %> <br>
+  <%= trip.start_date %> <br>
+  <%= trip.start_station.name %> <br>
+  <%= trip.end_date %> <br>
+  <%= trip.end_station.name %> <br>
+  <%= trip.bike_id %> <br>
+  <%= trip.subscription_type %> <br>
+  <%= trip.zip_code %> <br>
 <% end %>
+<%= paginate @trips %> <br>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -8,5 +8,6 @@
   <%= trip.bike_id %> <br>
   <%= trip.subscription_type %> <br>
   <%= trip.zip_code %> <br>
+  <%= link_to "Delete", trip_path(trip), method: "delete" if current_admin? %>
 <% end %>
 <%= paginate @trips %> <br>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -8,6 +8,7 @@
   <%= trip.bike_id %> <br>
   <%= trip.subscription_type %> <br>
   <%= trip.zip_code %> <br>
-  <%= link_to "Delete", trip_path(trip), method: "delete" if current_admin? %>
+  <%= link_to "Edit Trip", edit_trip_path(trip) if current_admin? %>
+  <%= link_to "Delete Trip", trip_path(trip), method: "delete" if current_admin? %>
 <% end %>
 <%= paginate @trips %> <br>

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form" %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -1,0 +1,8 @@
+<%= @trip.duration %>
+<%= @trip.start_date %>
+<%= @trip.start_station.name %>
+<%= @trip.end_date %>
+<%= @trip.end_station.name %>
+<%= @trip.bike_id %>
+<%= @trip.subscription_type %>
+<%= @trip.zip_code %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -6,3 +6,4 @@
 <%= @trip.bike_id %>
 <%= @trip.subscription_type %>
 <%= @trip.zip_code %>
+<%= link_to "Delete", trip_path(@trip), method: "delete" if current_admin? %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -6,4 +6,5 @@
 <%= @trip.bike_id %>
 <%= @trip.subscription_type %>
 <%= @trip.zip_code %>
-<%= link_to "Delete", trip_path(@trip), method: "delete" if current_admin? %>
+<%= link_to "Edit Trip", edit_trip_path(@trip) if current_admin? %>
+<%= link_to "Delete Trip", trip_path(@trip), method: "delete" if current_admin? %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 30
+  config.max_per_page = nil
+  config.window = 4
+  config.outer_window = 0
+  config.left = 0
+  config.right = 0
+  config.page_method_name = :page
+  config.param_name = :page
+  config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,11 @@ Rails.application.routes.draw do
 
   resources :stations
 
+  resources :trips
+
   resources :conditions
 
   resources :users, except: [:index, :destroy, :show]
-  
-  resources :trips
 
   get "/stations-dashboard", :to => "stations_dashboard#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,12 @@ Rails.application.routes.draw do
   root "welcome#index"
 
   resources :stations
+
   resources :conditions
 
   resources :users, except: [:index, :destroy, :show]
+  
+  resources :trips
 
   get "/stations-dashboard", :to => "stations_dashboard#index"
 

--- a/db/migrate/20180219192755_create_trips.rb
+++ b/db/migrate/20180219192755_create_trips.rb
@@ -1,0 +1,14 @@
+class CreateTrips < ActiveRecord::Migration[5.1]
+  def change
+    create_table :trips do |t|
+      t.integer :duration
+      t.datetime :start_date
+      t.datetime :end_date
+      t.integer :bike_id
+      t.string :subscription_type
+      t.integer :zip_code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180219202010_add_column_to_trips.rb
+++ b/db/migrate/20180219202010_add_column_to_trips.rb
@@ -1,0 +1,6 @@
+class AddColumnToTrips < ActiveRecord::Migration[5.1]
+  def change
+    add_column :trips, :start_station_id, :integer
+    add_column :trips, :end_station_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219192755) do
+ActiveRecord::Schema.define(version: 20180219202010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20180219192755) do
     t.integer "zip_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "start_station_id"
+    t.integer "end_station_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219224707) do
-
+ActiveRecord::Schema.define(version: 20180219192755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +46,17 @@ ActiveRecord::Schema.define(version: 20180219224707) do
     t.text "city"
     t.datetime "installation_date"
     t.string "slug"
+  end
+
+  create_table "trips", force: :cascade do |t|
+    t.integer "duration"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.integer "bike_id"
+    t.string "subscription_type"
+    t.integer "zip_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     bike_id 1
     subscription_type "MyString"
     zip_code 1
+    start_station_id station
+    end_station_id station, name: "Station 2"
   end
 end

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
+
   factory :trip do
     duration 1
     start_date "2018-02-19 12:27:55"
@@ -6,7 +7,7 @@ FactoryBot.define do
     bike_id 1
     subscription_type "MyString"
     zip_code 1
-    start_station_id station
-    end_station_id station, name: "Station 2"
+    start_station_id 1
+    end_station_id 1
   end
 end

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :trip do
+    duration 1
+    start_date "2018-02-19 12:27:55"
+    end_date "2018-02-19 12:27:55"
+    bike_id 1
+    subscription_type "MyString"
+    zip_code 1
+  end
+end

--- a/spec/features/trips/admin_can_create_trip_spec.rb
+++ b/spec/features/trips/admin_can_create_trip_spec.rb
@@ -27,4 +27,20 @@ describe "As an Admin" do
       expect(page).to have_content("Trip created")
     end
   end
+
+    describe "when I visit the trips new page and fill in form with all but one attribute" do
+      it "I see a flash message for errors" do
+        visit new_trip_path
+        fill_in "trip[duration]", with: "100"
+        fill_in "trip[start_date]", with: Time.now
+        fill_in "trip[start_station_id]", with: "1"
+        fill_in "trip[end_date]", with: Time.now
+        fill_in "trip[bike_id]", with: "2"
+        fill_in "trip[subscription_type]", with: "rider"
+        fill_in "trip[zip_code]", with: "60608"
+        click_on "Create"
+
+        expect(page).to have_content("Trip not created. Try again.")
+      end
+    end
 end

--- a/spec/features/trips/admin_can_create_trip_spec.rb
+++ b/spec/features/trips/admin_can_create_trip_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe "As an Admin" do
+  before :all do
+    @station = create(:station)
+  end
+  before :each do
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+
+  describe "when I visit the trips new page and fill in form with all attributes" do
+    it "I am redirected to the trip's show page and see trip's updated info" do
+      visit new_trip_path
+      fill_in "trip[duration]", with: "100"
+      fill_in "trip[start_date]", with: Time.now
+      fill_in "trip[start_station_id]", with: "1"
+      fill_in "trip[end_date]", with: Time.now
+      fill_in "trip[end_station_id]", with: "1"
+      fill_in "trip[bike_id]", with: "2"
+      fill_in "trip[subscription_type]", with: "rider"
+      fill_in "trip[zip_code]", with: "60608"
+      click_on "Create"
+
+      expect(current_path).to eq(trip_path(Trip.last))
+      expect(page).to have_content("100")
+      expect(page).to have_content("Trip created")
+    end
+  end
+end

--- a/spec/features/trips/admin_can_destroy_trip_spec.rb
+++ b/spec/features/trips/admin_can_destroy_trip_spec.rb
@@ -5,6 +5,11 @@ describe "As an Admin" do
     @station = create(:station)
     @trip = create(:trip)
   end
+  before :each do
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+
   describe "when I visit trip index page" do
     it "I can delete a trip" do
       visit trips_path
@@ -12,12 +17,18 @@ describe "As an Admin" do
 
       expect(current_path).to eq(trips_path)
       expect(page).to_not have_content(@trip.id)
+      expect(page).to have_content("Trip deleted")
     end
   end
 
-  describe "when I visit trip index page" do
+  describe "when I visit trip show page" do
     it "I can delete a trip" do
       visit trip_path(@trip)
+      click_on "Delete"
+
+      expect(current_path).to eq(trips_path)
+      expect(page).to_not have_content(@trip.id)
+      expect(page).to have_content("Trip deleted")
     end
   end
 end

--- a/spec/features/trips/admin_can_destroy_trip_spec.rb
+++ b/spec/features/trips/admin_can_destroy_trip_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "As an Admin" do
+  before :all do
+    @station = create(:station)
+    @trip = create(:trip)
+  end
+  describe "when I visit trip index page" do
+    it "I can delete a trip" do
+      visit trips_path
+      click_on "Delete"
+
+      expect(current_path).to eq(trips_path)
+      expect(page).to_not have_content(@trip.id)
+    end
+  end
+
+  describe "when I visit trip index page" do
+    it "I can delete a trip" do
+      visit trip_path(@trip)
+    end
+  end
+end

--- a/spec/features/trips/admin_can_edit_a_trip_spec.rb
+++ b/spec/features/trips/admin_can_edit_a_trip_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "As an Admin" do
+  before :all do
+    @station = create(:station)
+    @trip = create(:trip)
+  end
+  before :each do
+    @admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+  end
+
+  describe "when I visit the trips show page and click edit and fill in form" do
+    it "I am redirected to the trip's show page and see trip's updated info" do
+      visit trip_path(@trip)
+      click_on "Edit"
+      fill_in "Duration", with: "100"
+      click_on "Update"
+
+      expect(current_path).to eq(trip_path(@trip))
+      expect(page).to have_content("100")
+    end
+  end
+end

--- a/spec/features/trips/admin_can_edit_a_trip_spec.rb
+++ b/spec/features/trips/admin_can_edit_a_trip_spec.rb
@@ -19,6 +19,7 @@ describe "As an Admin" do
 
       expect(current_path).to eq(trip_path(@trip))
       expect(page).to have_content("100")
+      expect(page).to have_content("Trip updated")
     end
   end
 end

--- a/spec/features/trips/user_can_see_all_trips_spec.rb
+++ b/spec/features/trips/user_can_see_all_trips_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe "As a visitor" do
   before :each do
-    
+    @station = create(:station)
     @trips = create_list(:trip, 60)
   end
   describe "when I visit trips index" do
     it "I see first 30 trips" do
       visit trips_path
 
-      expect(page).to have_content(@trips[0..30].each {|trip| trip.duration})
+      expect(page).to have_content(@trips[0..30].map {|trip| trip.duration})
     end
   end
 end

--- a/spec/features/trips/user_can_see_all_trips_spec.rb
+++ b/spec/features/trips/user_can_see_all_trips_spec.rb
@@ -9,7 +9,17 @@ describe "As a visitor" do
     it "I see first 30 trips" do
       visit trips_path
 
-      expect(page).to have_content(@trips[0..30].map {|trip| trip.duration})
+      expect(page).to have_content(@trips[0].id)
+      expect(page).to have_content(@trips[0].duration)
+      expect(page).to have_content(@trips[0].start_date)
+      expect(page).to have_content(@trips[0].start_station.name)
+      expect(page).to have_content(@trips[0].end_date)
+      expect(page).to have_content(@trips[0].end_station.name)
+      expect(page).to have_content(@trips[0].bike_id)
+      expect(page).to have_content(@trips[0].subscription_type)
+      expect(page).to have_content(@trips[0].zip_code)
+      expect(page).to have_content(@trips[30].duration)
+      expect(page).to_not have_content(@trips[31].id)
     end
   end
 end

--- a/spec/features/trips/user_can_see_all_trips_spec.rb
+++ b/spec/features/trips/user_can_see_all_trips_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe "As a visitor" do
+  before :each do
+    
+    @trips = create_list(:trip, 60)
+  end
+  describe "when I visit trips index" do
+    it "I see first 30 trips" do
+      visit trips_path
+
+      expect(page).to have_content(@trips[0..30].each {|trip| trip.duration})
+    end
+  end
+end

--- a/spec/features/trips/visitor_can_see_all_trips_spec.rb
+++ b/spec/features/trips/visitor_can_see_all_trips_spec.rb
@@ -6,7 +6,7 @@ describe "As a visitor" do
     @trips = create_list(:trip, 60)
   end
   describe "when I visit trips index" do
-    it "I see first 30 trips" do
+    it "I see first 30 trips and click next and see the next 30 trips" do
       visit trips_path
 
       expect(page).to have_content(@trips[0].id)
@@ -18,8 +18,16 @@ describe "As a visitor" do
       expect(page).to have_content(@trips[0].bike_id)
       expect(page).to have_content(@trips[0].subscription_type)
       expect(page).to have_content(@trips[0].zip_code)
+      expect(page).to have_content(@trips[29].id)
+      expect(page).to_not have_content("Trip ID: #{@trips[30].id}")
+
+      visit trips_path
+      click_on "Next"
+      save_and_open_page
+      expect(page).to have_content(@trips[30].id)
       expect(page).to have_content(@trips[30].duration)
-      expect(page).to_not have_content(@trips[31].id)
+      expect(page).to have_content(@trips[59].duration)
+      expect(page).to_not have_content("Trip ID: #{@trips[29].id}")
     end
   end
 end

--- a/spec/features/trips/visitor_can_see_all_trips_spec.rb
+++ b/spec/features/trips/visitor_can_see_all_trips_spec.rb
@@ -23,7 +23,7 @@ describe "As a visitor" do
 
       visit trips_path
       click_on "Next"
-      save_and_open_page
+  
       expect(page).to have_content(@trips[30].id)
       expect(page).to have_content(@trips[30].duration)
       expect(page).to have_content(@trips[59].duration)

--- a/spec/features/trips/visitor_can_see_one_trip_spec.rb
+++ b/spec/features/trips/visitor_can_see_one_trip_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "As a visitor" do
+  before :each do
+    @station = create(:station)
+    @trip = create(:trip)
+  end
+  describe "when I visit a trip show page" do
+    it "I see all attributes for trip" do
+      visit trip_path(@trip)
+
+      expect(page).to have_content(@trip.duration)
+      expect(page).to have_content(@trip.start_date)
+      expect(page).to have_content(@trip.start_station.name)
+      expect(page).to have_content(@trip.end_date)
+      expect(page).to have_content(@trip.end_station.name)
+      expect(page).to have_content(@trip.bike_id)
+      expect(page).to have_content(@trip.subscription_type)
+      expect(page).to have_content(@trip.zip_code)
+    end
+  end
+end

--- a/spec/features/trips/visitor_can_see_one_trip_spec.rb
+++ b/spec/features/trips/visitor_can_see_one_trip_spec.rb
@@ -8,7 +8,7 @@ describe "As a visitor" do
   describe "when I visit a trip show page" do
     it "I see all attributes for trip" do
       visit trip_path(@trip)
-
+      save_and_open_page
       expect(page).to have_content(@trip.duration)
       expect(page).to have_content(@trip.start_date)
       expect(page).to have_content(@trip.start_station.name)

--- a/spec/features/trips/visitor_can_see_one_trip_spec.rb
+++ b/spec/features/trips/visitor_can_see_one_trip_spec.rb
@@ -8,7 +8,7 @@ describe "As a visitor" do
   describe "when I visit a trip show page" do
     it "I see all attributes for trip" do
       visit trip_path(@trip)
-      save_and_open_page
+
       expect(page).to have_content(@trip.duration)
       expect(page).to have_content(@trip.start_date)
       expect(page).to have_content(@trip.start_station.name)

--- a/spec/features/trips/visitor_cannot_edit_or_delete_a_trip_spec.rb
+++ b/spec/features/trips/visitor_cannot_edit_or_delete_a_trip_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "As a visitor" do
+describe "As a Visitor" do
   before :all do
     @station = create(:station)
     @trip = create(:trip)

--- a/spec/features/trips/visitor_cannot_edit_or_delete_a_trip_spec.rb
+++ b/spec/features/trips/visitor_cannot_edit_or_delete_a_trip_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "As a visitor" do
+  before :all do
+    @station = create(:station)
+    @trip = create(:trip)
+  end
+
+  describe "when I visit the trips index page" do
+    it "I do not see edit or delete buttons next to each trip" do
+      visit trips_path
+
+      expect(page).to_not have_content("Delete")
+      expect(page).to_not have_content("Edit")
+    end
+  end
+
+  describe "when I try to visit trip/:id/edit" do
+    it "I am redirected to a 404 page" do
+      visit edit_trip_path(@trip)
+
+      expect(page).to have_content("The page you were looking for doesn't exist")
+    end
+  end
+
+  describe "when I try to visit trips/new" do
+    it "I am redirected to a 404 page" do
+      visit new_trip_path
+
+      expect(page).to have_content("The page you were looking for doesn't exist")
+    end
+  end
+end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
-describe Trip, type: :model do
-  it { should validate_presence_of(:duration) }
-  it { should validate_presence_of(:start_date) }
-  it { should validate_presence_of(:start_station_id) }
-  it { should validate_presence_of(:end_date) }
-  it { should validate_presence_of(:end_station_id) }
-  it { should validate_presence_of(:bike_id) }
-  it { should validate_presence_of(:subscription_type) }
-  it { should validate_presence_of(:zip_code) }
+RSpec.describe Trip, type: :model do
+  it { should validate_presence_of(:duration)}
+  it { should validate_presence_of(:start_date)}
+  it { should validate_presence_of(:end_date)}
+  it { should validate_presence_of(:bike_id)}
+  it { should validate_presence_of(:subscription_type)}
+  it { should validate_presence_of(:zip_code)}
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,10 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Trip, type: :model do
-  it { should validate_presence_of(:duration)}
-  it { should validate_presence_of(:start_date)}
-  it { should validate_presence_of(:end_date)}
-  it { should validate_presence_of(:bike_id)}
-  it { should validate_presence_of(:subscription_type)}
-  it { should validate_presence_of(:zip_code)}
+describe Trip, type: :model do
+  it { should validate_presence_of(:duration) }
+  it { should validate_presence_of(:start_date) }
+  it { should validate_presence_of(:end_date) }
+  it { should validate_presence_of(:bike_id) }
+  it { should validate_presence_of(:subscription_type) }
+  it { should validate_presence_of(:zip_code) }
+
+  describe "relationships" do
+    it { is_expected.to belong_to(:start_station) }
+    it { is_expected.to belong_to(:end_station) }
+  end
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Trip, type: :model do
+  it { should validate_presence_of(:duration) }
+  it { should validate_presence_of(:start_date) }
+  it { should validate_presence_of(:start_station_id) }
+  it { should validate_presence_of(:end_date) }
+  it { should validate_presence_of(:end_station_id) }
+  it { should validate_presence_of(:bike_id) }
+  it { should validate_presence_of(:subscription_type) }
+  it { should validate_presence_of(:zip_code) }
+end


### PR DESCRIPTION
# Added Features:

* Added all CRUD functionality for Trips
* Added Kiminari gem (https://github.com/kaminari/kaminari)
* Added trip relationships to stations on model level
NOTE: I couldn't create the relationships on the db level since you can't migrate the same relationship twice. Informative article about how to create multiple relationships with the same table on the model level here: https://www.spacevatican.org/2008/5/6/creating-multiple-associations-with-the-same-table/

# Benefits (why)
* Kiminari was pretty simple to use and doesn't add extras we don't need.

# Possible Drawbacks (optional)
* Trip Factory Bot uses 1 for start_station_id and end_station_id. Need to make sure you create a station in your test when you are creating a trip. Adds some inflexibility to testing. 

# Checklist:

Answer the following questions -
* Are all tests passing? Y
* Have you tested your new feature? Y
* Have you tested it on localhost? Y

# Additional Comments:
* I am awesome.
