### PR TITLE
Edit user

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --require spec_helper
---format=documentation

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,11 @@ class ApplicationController < ActionController::Base
     render file: "/public/404" unless current_user
   end
 
+  def require_login
+    flash[:notice] = "Please log in first" unless current_user
+    redirect_to login_path unless current_user
+  end
+
   def current_user
   @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :current_user, :current_admin?
+  helper_method :current_user, :current_admin?, :made_with
 
   def require_admin
     render file: "/public/404" unless current_admin?
@@ -17,5 +17,14 @@ class ApplicationController < ActionController::Base
 
   def current_admin?
     current_user && current_user.admin?
+  end
+
+  def made_with
+    [
+    "Malice of Forethought", "Careful Minelaying", "Overflowing Love", "Changing Intentions", "Different Ideas",
+    "Revolving Pinatas", "Generous Crocodiles", "Pure Coffee", "Random Arrays", "Fortunate Cookies",
+    "Goliath Trucks", "Some Code", "5 Year Old's Help", "General Kenobi", "Xenoplastic Morphology", "Ellen's Positivity",
+    "Luis' Artistic Genius", "Luke's Ideaologies"
+    ]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :require_user, except: [:new, :create]
+  before_action :require_login, except: [:new, :create]
 
   def new
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :require_user, except: [:new, :create]
 
   def new
     @user = User.new

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -1,3 +1,4 @@
 Logged in as <%= @user.name %>
 Current Email: <%= @user.email %>
 <%= link_to "Logout", logout_path, method: "destroy" if current_user %>
+See something that doesn't look right? <%= link_to "Edit Profile", edit_user_path(@user) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <% end %>
     <%= yield %>
     <footer class="footer">
-      <h2>Made with Love By <%= link_to "Luis Senior", "https://github.com/Heybluguy" %>, <%= link_to "Ellen Cornelius", "https://github.com/corneliusellen" %>, and <%= link_to "Luke Chambers", "https://github.com/lnchambers" %></h2>
+      <h2>Made with <%= made_with.sample %> By <%= link_to "Luis Senior", "https://github.com/Heybluguy" %>, <%= link_to "Ellen Cornelius", "https://github.com/corneliusellen" %>, and <%= link_to "Luke Chambers", "https://github.com/lnchambers" %></h2>
     </footer>
   </body>
 </html>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,2 @@
+Edit your profile, <%= @user.name %>
+<%= render partial: "form" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
 Logged in as <%= @user.name %>
 Current Email: <%= @user.email %>
 <%= link_to "Logout", logout_path, method: "destroy" if current_user %>
+See something that doesn't look right? <%= link_to "Edit Profile", edit_user_path(@user) %>

--- a/spec/features/users/user_can_edit_their_profile_spec.rb
+++ b/spec/features/users/user_can_edit_their_profile_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "As a registered User or Admin" do
+  before :all do
+    @admin = create(:admin)
+    @user = create(:user)
+  end
+  describe "when I visit the edit user path" do
+    it "admin can edit only their own information" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+      visit edit_user_path(@admin)
+
+      expect(page).to have_content("Edit your profile, #{@admin.name}")
+      expect(page).to_not have_content(@user.name)
+    end
+
+    it "user can edit only their own information" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit edit_user_path(@user)
+
+      expect(page).to have_content("Edit your profile, #{@user.name}")
+      expect(page).to_not have_content(@admin.name)
+    end
+
+    it "visitor cannot get to the edit user page" do
+      visit edit_user_path(@user)
+
+      expect(page).to have_content("The page you were looking for was not found")
+    end
+
+    it "I cannot edit another users path" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+      visit edit_user_path(@user)
+
+      expect(page).to have_content("The page you were looking for was not found")
+    end
+  end
+
+  describe "when I visit the user dashboard" do
+    it "admin can see a link to edit their profile" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+      visit admin_dashboard_path
+
+      click_on "Edit Profile"
+
+      expect(current_path).to eq(edit_user_path(@admin))
+      expect(page).to have_content("Edit your profile, #{@admin.name}")
+    end
+
+    it "user can see a link to edit their profile" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit dashboard_path
+
+      click_on "Edit Profile"
+
+      expect(current_path).to eq(edit_user_path(@user))
+      expect(page).to have_content("Edit your profile, #{@user.name}")
+    end
+  end
+end

--- a/spec/features/users/user_can_edit_their_profile_spec.rb
+++ b/spec/features/users/user_can_edit_their_profile_spec.rb
@@ -25,14 +25,14 @@ describe "As a registered User or Admin" do
     it "visitor cannot get to the edit user page" do
       visit edit_user_path(@user)
 
-      expect(page).to have_content("The page you were looking for was not found")
+      expect(page).to have_content("The page you were looking for doesn't exist")
     end
 
     it "I cannot edit another users path" do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
       visit edit_user_path(@user)
 
-      expect(page).to have_content("The page you were looking for was not found")
+      expect(page).to have_content("Edit your profile, #{@admin.name}")
     end
   end
 

--- a/spec/features/users/user_can_edit_their_profile_spec.rb
+++ b/spec/features/users/user_can_edit_their_profile_spec.rb
@@ -25,7 +25,7 @@ describe "As a registered User or Admin" do
     it "visitor cannot get to the edit user page" do
       visit edit_user_path(@user)
 
-      expect(page).to have_content("The page you were looking for doesn't exist")
+      expect(page).to have_content("Please log in first")
     end
 
     it "I cannot edit another users path" do


### PR DESCRIPTION
# Added Features:

* User can now edit their own profile. Visitors attempting to edit a profile will be redirected to login first.

# Benefits (why)

Asking a user to log in is nicer then telling them the website doesn't exist anymore.

# Possible Drawbacks (optional)

The method require_login will redirect visitors to login if they attempt to access any point where they need to login. That being said, the method looks a little funky, so take a look at it and let we can refactor it later.

# Checklist:

Answer the following questions -
* Are all tests passing? Y
* Have you tested your new feature? Y
* Have you tested it on localhost? Y

# Additional Comments:

New methods:

* require_login (view_helper )
 - Redirects visitors to login if they try to access a page where we want them to login in.

![1238064836_kid_vs_pole](https://user-images.githubusercontent.com/32661560/36454204-30facf20-1658-11e8-85b5-b03aa77f6f8d.gif)
